### PR TITLE
Add menu update API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+When you change API routes or controllers, update the Postman collection file `postman/go-fiber-template.postman_collection.json` so it reflects all available endpoints. Include example request bodies for create and update operations when relevant.
+Always run `go vet ./...` and `go test ./...` after making changes and report the results.

--- a/controllers/menu_controller.go
+++ b/controllers/menu_controller.go
@@ -1,0 +1,117 @@
+package controllers
+
+import (
+	"go-fiber-api/models"
+	"go-fiber-api/repositories"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type MenuController struct {
+	Repo *repositories.MenuRepository
+}
+
+func NewMenuController(repo *repositories.MenuRepository) *MenuController {
+	return &MenuController{Repo: repo}
+}
+
+func (ctrl *MenuController) CreateMenu(c *fiber.Ctx) error {
+	var menu models.Menu
+	if err := c.BodyParser(&menu); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid data",
+			Data:    nil,
+		})
+	}
+
+	if err := ctrl.Repo.Create(c.Context(), &menu); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Unable to create menu",
+			Data:    nil,
+		})
+	}
+
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Created menu successfully",
+		Data:    menu,
+	})
+}
+
+func (ctrl *MenuController) GetMenus(c *fiber.Ctx) error {
+	menus, err := ctrl.Repo.GetAll(c.Context())
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Cannot get menu list",
+			Data:    nil,
+		})
+	}
+
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Get menu list successfully",
+		Data:    menus,
+	})
+}
+
+func (ctrl *MenuController) DeleteMenu(c *fiber.Ctx) error {
+	id := c.Query("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+
+	if err := ctrl.Repo.DeleteByID(c.Context(), id); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: err.Error(),
+			Data:    nil,
+		})
+	}
+
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Deleted menu successfully",
+		Data:    nil,
+	})
+}
+
+func (ctrl *MenuController) UpdateMenu(c *fiber.Ctx) error {
+	id := c.Query("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Missing id",
+			Data:    nil,
+		})
+	}
+
+	var menu models.Menu
+	if err := c.BodyParser(&menu); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+			Status:  "error",
+			Message: "Invalid data",
+			Data:    nil,
+		})
+	}
+
+	if err := ctrl.Repo.UpdateByID(c.Context(), id, &menu); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+			Status:  "error",
+			Message: err.Error(),
+			Data:    nil,
+		})
+	}
+
+	return c.JSON(models.APIResponse{
+		Status:  "success",
+		Message: "Updated menu successfully",
+		Data:    menu,
+	})
+}

--- a/models/menu.go
+++ b/models/menu.go
@@ -1,0 +1,13 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+type Menu struct {
+	ID            primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Title         string             `json:"title" bson:"title"`
+	Key           string             `json:"key" bson:"key"`
+	URL           string             `json:"url" bson:"url"`
+	Icon          string             `json:"icon" bson:"icon"`
+	ParentID      primitive.ObjectID `json:"parent_Id" bson:"parent_Id"`
+	PermissionBit int64              `json:"permissionBit" bson:"permissionBit"`
+}

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -1,195 +1,320 @@
 {
-	"info": {
-		"_postman_id": "c743d2e4-464d-4cdb-a5b1-f97c3966c25d",
-		"name": "Go Fiber Template API",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "12357742"
-	},
-	"item": [
-		{
-			"name": "Auth",
-			"item": [
-				{
-					"name": "Login",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Login response has token\", function () {\r",
-									"    var jsonData = pm.response.json();\r",
-									"    pm.expect(jsonData.data.token).to.be.a(\"string\");\r",
-									"    pm.collectionVariables.set(\"token\", jsonData.data.token);\r",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"username\": \"admin\",\n  \"password\": \"admin123\"\n}"
-						},
-						"url": {
-							"raw": "{{baseUrl}}/login",
-							"host": [
-								"{{baseUrl}}"
-							],
-							"path": [
-								"login"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "User",
-			"item": [
-				{
-					"name": "Get Profile",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{baseUrl}}/api/me",
-							"host": [
-								"{{baseUrl}}"
-							],
-							"path": [
-								"api",
-								"me"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Users",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{baseUrl}}/api/users?role=admin",
-							"host": [
-								"{{baseUrl}}"
-							],
-							"path": [
-								"api",
-								"users"
-							],
-							"query": [
-								{
-									"key": "role",
-									"value": "admin"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create User",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"username\": \"user1\",\n  \"password\": \"pass\",\n  \"role\": \"member\"\n}"
-						},
-						"url": {
-							"raw": "{{baseUrl}}/api/users",
-							"host": [
-								"{{baseUrl}}"
-							],
-							"path": [
-								"api",
-								"users"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		}
-	],
-	"auth": {
-		"type": "bearer",
-		"bearer": [
-			{
-				"key": "token",
-				"value": "{{token}}",
-				"type": "string"
-			}
-		]
-	},
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"packages": {},
-				"exec": [
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"packages": {},
-				"exec": [
-					""
-				]
-			}
-		}
-	],
-	"variable": [
-		{
-			"key": "baseUrl",
-			"value": "localhost:4000",
-			"type": "string"
-		},
-		{
-			"key": "token",
-			"value": ""
-		}
-	]
+  "info": {
+    "_postman_id": "c743d2e4-464d-4cdb-a5b1-f97c3966c25d",
+    "name": "Go Fiber Template API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "12357742"
+  },
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Login response has token\", function () {\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.data.token).to.be.a(\"string\");\r",
+                  "    pm.collectionVariables.set(\"token\", jsonData.data.token);\r",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"admin\",\n  \"password\": \"admin123\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "login"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "User",
+      "item": [
+        {
+          "name": "Get Profile",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Users",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/users?role=admin",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "users"
+              ],
+              "query": [
+                {
+                  "key": "role",
+                  "value": "admin"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"user1\",\n  \"password\": \"pass\",\n  \"role\": \"member\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "users"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Menu",
+      "item": [
+        {
+          "name": "Get Menus",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/menus",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "menus"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Menu",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\\n  \\\"title\\\": \\\"1\\\",\\n  \\\"key\\\": \\\"1\\\",\\n  \\\"url\\\": \\\"/\\\",\\n  \\\"icon\\\": \\\"/\\\",\\n  \\\"parent_Id\\\": \\\"000000000000000000000000\\\",\\n  \\\"permissionBit\\\": 0\\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/menus",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "menus"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Menu",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\\n  \\\"title\\\": \\\"Updated\\\",\\n  \\\"key\\\": \\\"menu-updated\\\",\\n  \\\"url\\\": \\\"/new\\\",\\n  \\\"icon\\\": \\\"icon\\\",\\n  \\\"parent_Id\\\": \\\"000000000000000000000000\\\",\\n  \\\"permissionBit\\\": 1\\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/menus?id=000000000000000000000000",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "menus"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "000000000000000000000000"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Menu",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/menus?id=000000000000000000000000",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "menus"
+              ],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "000000000000000000000000"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "localhost:4000",
+      "type": "string"
+    },
+    {
+      "key": "token",
+      "value": ""
+    }
+  ]
 }

--- a/repositories/menu_repository.go
+++ b/repositories/menu_repository.go
@@ -1,0 +1,83 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"go-fiber-api/models"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type MenuRepository struct {
+	collection *mongo.Collection
+}
+
+func NewMenuRepository(db *mongo.Database) *MenuRepository {
+	return &MenuRepository{collection: db.Collection("menus")}
+}
+
+func (r *MenuRepository) Create(ctx context.Context, menu *models.Menu) error {
+	menu.ID = primitive.NewObjectID()
+	_, err := r.collection.InsertOne(ctx, menu)
+	return err
+}
+
+func (r *MenuRepository) GetAll(ctx context.Context) ([]models.Menu, error) {
+	cursor, err := r.collection.Find(ctx, bson.M{})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var menus []models.Menu
+	for cursor.Next(ctx) {
+		var m models.Menu
+		if err := cursor.Decode(&m); err != nil {
+			return nil, err
+		}
+		menus = append(menus, m)
+	}
+	return menus, nil
+}
+
+func (r *MenuRepository) DeleteByID(ctx context.Context, id string) error {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	res, err := r.collection.DeleteOne(ctx, bson.M{"_id": objID})
+	if err != nil {
+		return err
+	}
+	if res.DeletedCount == 0 {
+		return errors.New("menu not found")
+	}
+	return nil
+}
+
+func (r *MenuRepository) UpdateByID(ctx context.Context, id string, menu *models.Menu) error {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+
+	update := bson.M{"$set": bson.M{
+		"title":         menu.Title,
+		"key":           menu.Key,
+		"url":           menu.URL,
+		"icon":          menu.Icon,
+		"parent_Id":     menu.ParentID,
+		"permissionBit": menu.PermissionBit,
+	}}
+
+	res, err := r.collection.UpdateOne(ctx, bson.M{"_id": objID}, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return errors.New("menu not found")
+	}
+	menu.ID = objID
+	return nil
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,6 +13,8 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	// Initialize repositories and controllers once so they can be reused
 	userRepo := repositories.NewUserRepository(db)
 	userCtrl := controllers.NewUserController(userRepo)
+	menuRepo := repositories.NewMenuRepository(db)
+	menuCtrl := controllers.NewMenuController(menuRepo)
 
 	// Public routes do not require authentication
 	app.Post("/login", controllers.Login)
@@ -31,4 +33,10 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	admin := api.Group("/users", middleware.AdminOnly())
 	admin.Post("/", userCtrl.CreateUser)
 	admin.Get("/", userCtrl.GetUsersByRole)
+
+	menuAdmin := api.Group("/menus", middleware.AdminOnly())
+	menuAdmin.Post("/", menuCtrl.CreateMenu)
+	menuAdmin.Put("/", menuCtrl.UpdateMenu)
+	menuAdmin.Get("/", menuCtrl.GetMenus)
+	menuAdmin.Delete("/", menuCtrl.DeleteMenu)
 }


### PR DESCRIPTION
## Summary
- add UpdateByID method to menu repository
- add UpdateMenu handler and route
- register PUT /api/menus for admin
- update Postman collection with menu endpoints and example payloads
- document update process in AGENTS instructions

## Testing
- `go vet ./...` *(fails: no required module provides package go.mongodb.org/mongo-driver/mongo/inmemory)*
- `go test ./...` *(fails: no required module provides package go.mongodb.org/mongo-driver/mongo/inmemory)*

------
https://chatgpt.com/codex/tasks/task_b_685cb56bc658833198736263a7cb209b