### PR TITLE
Add role group seeding

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,9 +25,10 @@ func main() {
 	config.ConnectDB()
 
 	// Seed default accounts if needed
-    seed.SeedAdminUser()
-    seed.SeedDefaultUser()
-    seed.SeedMenus()
+	seed.SeedRoleGroups()
+	seed.SeedAdminUser()
+	seed.SeedDefaultUser()
+	seed.SeedMenus()
 
 	app := fiber.New()
 	app.Use(cors.New())

--- a/seed/role_group.go
+++ b/seed/role_group.go
@@ -1,0 +1,44 @@
+package seed
+
+import (
+	"context"
+	"fmt"
+
+	"go-fiber-api/config"
+	"go-fiber-api/models"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// SeedRoleGroups seeds default role groups if they don't already exist.
+func SeedRoleGroups() {
+	collection := config.DB.Collection("role_groups")
+
+	adminID, _ := primitive.ObjectIDFromHex("685d01ab5e17ba55d0e349f2")
+	adminGroup := models.RoleGroup{
+		ID:          adminID,
+		Name:        "admin",
+		Description: "gioi thieu",
+		Permission: []models.PermissionDetail{
+			{Key: "menu", PermissionValue: 10},
+			{Key: "menu-euoi92n7f0", PermissionValue: 0},
+			{Key: "menu-byy4w5x6la", PermissionValue: 2},
+		},
+	}
+
+	var existing models.RoleGroup
+	err := collection.FindOne(context.TODO(), bson.M{"_id": adminID}).Decode(&existing)
+	if err == mongo.ErrNoDocuments {
+		if _, err := collection.InsertOne(context.TODO(), adminGroup); err != nil {
+			fmt.Println("❌ Failed to seed role group:", err)
+			return
+		}
+		fmt.Println("🚀 Role group seeded:", adminGroup.Name)
+	} else if err == nil {
+		fmt.Println("✅ Role group already exists:", adminGroup.Name)
+	} else {
+		fmt.Println("❌ Failed checking role group:", err)
+	}
+}

--- a/seed/user.go
+++ b/seed/user.go
@@ -21,12 +21,13 @@ func SeedAdminUser() {
 		return
 	}
 	password, _ := utils.HashPassword("admin123")
+	groupID, _ := primitive.ObjectIDFromHex("685d01ab5e17ba55d0e349f2")
 	admin := models.User{
 		Username:   "admin",
 		Password:   password,
 		Role:       "admin",
 		Name:       "Administrator",
-		RoleGroups: []primitive.ObjectID{},
+		RoleGroups: []primitive.ObjectID{groupID},
 	}
 
 	_, err = collection.InsertOne(context.TODO(), admin)


### PR DESCRIPTION
## Summary
- seed default role group with fixed ID
- assign this role group to the admin user
- update `main.go` to seed role groups before users

## Testing
- `go vet ./...` *(fails: no required module provides package `go.mongodb.org/mongo-driver/mongo/inmemory`)*
- `go test ./...` *(fails: no required module provides package `go.mongodb.org/mongo-driver/mongo/inmemory`)*

------
https://chatgpt.com/codex/tasks/task_b_685d0a2aba388331823ea8ce6b23146e