### PR TITLE
Add user permission aggregation API

### DIFF
--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -94,6 +94,29 @@
           ]
         },
         {
+          "name": "Get Permissions",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/permissions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "permissions"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Get Users",
           "request": {
             "method": "GET",

--- a/repositories/role_group_repository.go
+++ b/repositories/role_group_repository.go
@@ -41,6 +41,30 @@ func (r *RoleGroupRepository) Create(ctx context.Context, group *models.RoleGrou
 	return err
 }
 
+// GetByIDs returns all role groups matching the provided IDs.
+func (r *RoleGroupRepository) GetByIDs(ctx context.Context, ids []primitive.ObjectID) ([]models.RoleGroup, error) {
+	if len(ids) == 0 {
+		return []models.RoleGroup{}, nil
+	}
+
+	filter := bson.M{"_id": bson.M{"$in": ids}}
+	cursor, err := r.collection.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var groups []models.RoleGroup
+	for cursor.Next(ctx) {
+		var g models.RoleGroup
+		if err := cursor.Decode(&g); err != nil {
+			return nil, err
+		}
+		groups = append(groups, g)
+	}
+	return groups, nil
+}
+
 func (r *RoleGroupRepository) GetAll(ctx context.Context, search string, page, limit int64) ([]models.RoleGroup, int64, error) {
 	filter := bson.M{}
 	if search != "" {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -12,11 +12,11 @@ import (
 func Setup(app *fiber.App, db *mongo.Database) {
 	// Initialize repositories and controllers once so they can be reused
 	userRepo := repositories.NewUserRepository(db)
-	userCtrl := controllers.NewUserController(userRepo)
+	roleGroupRepo := repositories.NewRoleGroupRepository(db)
+	userCtrl := controllers.NewUserController(userRepo, roleGroupRepo)
 	authCtrl := controllers.NewAuthController(userRepo)
 	menuRepo := repositories.NewMenuRepository(db)
 	menuCtrl := controllers.NewMenuController(menuRepo)
-	roleGroupRepo := repositories.NewRoleGroupRepository(db)
 	roleGroupCtrl := controllers.NewRoleGroupController(roleGroupRepo)
 
 	// Public routes do not require authentication
@@ -29,6 +29,7 @@ func Setup(app *fiber.App, db *mongo.Database) {
 
 	// Endpoints accessible to any authenticated user
 	api.Get("/me", userCtrl.GetCurrentUser)
+	api.Get("/permissions", userCtrl.GetUserPermissions)
 	api.Put("/users/password", userCtrl.ChangeUserPassword)
 	api.Put("/presigned_url", controllers.GetUploadUrl)
 


### PR DESCRIPTION
## Summary
- expose RoleGroup repo in `UserController`
- add `GetUserPermissions` handler to compute merged permissions for the authenticated user
- support fetching multiple role groups via new `GetByIDs` repository method
- wire new endpoint in routes and update Postman collection

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685d276a1bac833189701f19601c948f