### PR TITLE
Add user avatar URL

### DIFF
--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -216,6 +216,7 @@ func (ctrl *UserController) UpdateUser(c *fiber.Ctx) error {
 	var req struct {
 		ID         primitive.ObjectID   `json:"id"`
 		Name       string               `json:"name"`
+		UrlAvatar  string               `json:"url_avatar"`
 		RoleGroups []primitive.ObjectID `json:"role_groups"`
 	}
 	if err := c.BodyParser(&req); err != nil || req.ID.IsZero() {
@@ -226,7 +227,7 @@ func (ctrl *UserController) UpdateUser(c *fiber.Ctx) error {
 		})
 	}
 
-	user, err := ctrl.Repo.UpdateByID(c.Context(), req.ID.Hex(), req.Name, req.RoleGroups)
+	user, err := ctrl.Repo.UpdateByID(c.Context(), req.ID.Hex(), req.Name, req.UrlAvatar, req.RoleGroups)
 	if err != nil {
 		status := fiber.StatusInternalServerError
 		if err.Error() == "user not found" {

--- a/models/user.go
+++ b/models/user.go
@@ -8,6 +8,7 @@ type User struct {
 	Username   string               `json:"username" bson:"username"`
 	Password   string               `json:"password,omitempty" bson:"password"`
 	Name       string               `json:"name" bson:"name"`
+	UrlAvatar  string               `json:"url_avatar" bson:"url_avatar"`
 	RoleGroups []primitive.ObjectID `json:"role_groups" bson:"role_groups"`
 }
 
@@ -16,6 +17,7 @@ type UserListItem struct {
 	ID         string              `json:"id"`
 	Username   string              `json:"username"`
 	Name       string              `json:"name"`
+	UrlAvatar  string              `json:"url_avatar"`
 	RoleGroups []RoleGroupListItem `json:"role_groups"`
 }
 
@@ -31,6 +33,7 @@ func (u User) ToListItem(groups map[primitive.ObjectID]RoleGroupListItem) UserLi
 		ID:         u.ID.Hex(),
 		Username:   u.Username,
 		Name:       u.Name,
+		UrlAvatar:  u.UrlAvatar,
 		RoleGroups: rg,
 	}
 }

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -177,7 +177,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"username\": \"user1\",\n  \"password\": \"pass\",\n  \"name\": \"User 1\",\n  \"role_groups\": [\n    \"000000000000000000000000\"\n  ]\n}"
+              "raw": "{\n  \"username\": \"user1\",\n  \"password\": \"pass\",\n  \"name\": \"User 1\",\n  \"url_avatar\": \"https://example.com/avatar.jpg\",\n  \"role_groups\": [\n    \"000000000000000000000000\"\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/users",
@@ -208,7 +208,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"id\": \"000000000000000000000000\",\n  \"name\": \"User 1\",\n  \"role_groups\": [\n    \"000000000000000000000000\"\n  ]\n}"
+              "raw": "{\n  \"id\": \"000000000000000000000000\",\n  \"name\": \"User 1\",\n  \"url_avatar\": \"https://example.com/avatar.jpg\",\n  \"role_groups\": [\n    \"000000000000000000000000\"\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/users",

--- a/repositories/user_repository.go
+++ b/repositories/user_repository.go
@@ -117,16 +117,16 @@ func (r *UserRepository) FindByID(ctx context.Context, id string) (*models.User,
 	return &user, nil
 }
 
-// UpdateByID updates user's non-password fields by id
-// UpdateByID updates the name and role groups of a user by id and returns the
-// updated document. Username and password cannot be changed here.
-func (r *UserRepository) UpdateByID(ctx context.Context, id string, name string, roleGroups []primitive.ObjectID) (*models.User, error) {
+// UpdateByID updates the name, avatar URL, and role groups of a user by id and
+// returns the updated document. Username and password cannot be changed here.
+func (r *UserRepository) UpdateByID(ctx context.Context, id string, name string, urlAvatar string, roleGroups []primitive.ObjectID) (*models.User, error) {
 	objID, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		return nil, err
 	}
 	update := bson.M{"$set": bson.M{
 		"name":        name,
+		"url_avatar":  urlAvatar,
 		"role_groups": roleGroups,
 	}}
 

--- a/seed/user.go
+++ b/seed/user.go
@@ -26,6 +26,7 @@ func SeedAdminUser() {
 		Username:   "admin",
 		Password:   password,
 		Name:       "Administrator",
+		UrlAvatar:  "",
 		RoleGroups: []primitive.ObjectID{groupID},
 	}
 
@@ -51,6 +52,7 @@ func SeedDefaultUser() {
 		Username:   "user",
 		Password:   password,
 		Name:       "Default User",
+		UrlAvatar:  "",
 		RoleGroups: []primitive.ObjectID{},
 	}
 


### PR DESCRIPTION
## Summary
- support storing a user avatar URL in the database
- allow updating `url_avatar` via API
- update Postman examples for create/update user
- seed users with empty `url_avatar`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685e67c69ea0833191523f62d1f836cc