### PR TITLE
Support updating profile via /api/me

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ assumes two variables:
 - `baseUrl` – base address of your running server, e.g. `http://localhost:4000`
 - `token` – JWT obtained from the `Login` request
 
-The collection contains examples for logging in, retrieving the current user
-and managing users as an admin.
+The collection contains examples for logging in, retrieving and updating the
+current user, and managing users as an admin.

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -294,6 +294,66 @@ func (ctrl *UserController) GetCurrentUser(c *fiber.Ctx) error {
 	})
 }
 
+// UpdateCurrentUser handles PUT /api/me to update the authenticated user's profile
+func (ctrl *UserController) UpdateCurrentUser(c *fiber.Ctx) error {
+       var req struct {
+               Name      string `json:"name"`
+               UrlAvatar string `json:"url_avatar"`
+       }
+       if err := c.BodyParser(&req); err != nil {
+               return c.Status(fiber.StatusBadRequest).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: "Invalid data",
+                       Data:    nil,
+               })
+       }
+
+       token := c.Locals("user").(*jwt.Token)
+       claims := token.Claims.(jwt.MapClaims)
+       id, _ := claims["id"].(string)
+
+       current, err := ctrl.Repo.FindByID(c.Context(), id)
+       if err != nil {
+               return c.Status(fiber.StatusNotFound).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: "User not found",
+                       Data:    nil,
+               })
+       }
+
+       user, err := ctrl.Repo.UpdateByID(c.Context(), id, req.Name, req.UrlAvatar, current.RoleGroups)
+       if err != nil {
+               status := fiber.StatusInternalServerError
+               if err.Error() == "user not found" {
+                       status = fiber.StatusNotFound
+               }
+               return c.Status(status).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: err.Error(),
+                       Data:    nil,
+               })
+       }
+       user.Password = ""
+       groups, err := ctrl.RoleGroupRepo.GetByIDs(c.Context(), user.RoleGroups)
+       if err != nil {
+               return c.Status(fiber.StatusInternalServerError).JSON(models.APIResponse{
+                       Status:  "error",
+                       Message: "Cannot get role groups",
+                       Data:    nil,
+               })
+       }
+       gm := make(map[primitive.ObjectID]models.RoleGroupListItem, len(groups))
+       for _, g := range groups {
+               gm[g.ID] = g.ToListItem()
+       }
+
+       return c.JSON(models.APIResponse{
+               Status:  "success",
+               Message: "Updated profile successfully",
+               Data:    user.ToListItem(gm),
+       })
+}
+
 // GetUserPermissions aggregates permissions from the user's role groups.
 func (ctrl *UserController) GetUserPermissions(c *fiber.Ctx) error {
 	token := c.Locals("user").(*jwt.Token)

--- a/postman/go-fiber-template.postman_collection.json
+++ b/postman/go-fiber-template.postman_collection.json
@@ -95,6 +95,37 @@
           ]
         },
         {
+          "name": "Update Profile",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"User 1\",\n  \"url_avatar\": \"https://example.com/avatar.jpg\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Get Permissions",
           "request": {
             "method": "GET",
@@ -482,7 +513,7 @@
               ]
             }
           },
-            "response": []
+          "response": []
         },
         {
           "name": "Role Group Detail",

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -28,7 +28,8 @@ func Setup(app *fiber.App, db *mongo.Database) {
 	api.Get("/test2", controllers.Hello)
 
 	// Endpoints accessible to any authenticated user
-	api.Get("/me", userCtrl.GetCurrentUser)
+    api.Get("/me", userCtrl.GetCurrentUser)
+    api.Put("/me", userCtrl.UpdateCurrentUser)
 	api.Get("/permissions", userCtrl.GetUserPermissions)
 	api.Put("/users/password", userCtrl.ChangeUserPassword)
 	api.Put("/presigned_url", controllers.GetUploadUrl)


### PR DESCRIPTION
## Summary
- allow authenticated users to update their profile
- expose new PUT `/api/me` route
- document new endpoint in the Postman collection
- mention update in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685e722deff883318e83bdbdb184fe3d